### PR TITLE
[Server]Fix/DBsetting/nullable수정

### DIFF
--- a/app/main/model/medicines.py
+++ b/app/main/model/medicines.py
@@ -12,11 +12,11 @@ class Medicines(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), nullable=False)
-    title = db.Column(db.String(255), nullable=False)
-    image_dir = db.Column(db.String(100), nullable=False)
-    effect = db.Column(db.Text, nullable=False)
-    capacity = db.Column(db.Text, nullable=False)
-    validity = db.Column(db.String(100), nullable=False)
+    title = db.Column(db.String(255), nullable=True)
+    image_dir = db.Column(db.String(100), nullable=True)
+    effect = db.Column(db.Text, nullable=True)
+    capacity = db.Column(db.Text, nullable=True)
+    validity = db.Column(db.String(100), nullable=True)
     camera = db.Column(db.Boolean, nullable=False)
 
     timetotake = db.relationship('Schedules_common', secondary=schedules_medicines, backref=db.backref('ttt', lazy='dynamic'))

--- a/app/main/model/schedules_common.py
+++ b/app/main/model/schedules_common.py
@@ -6,10 +6,10 @@ class Schedules_common(db.Model):
 
         id = db.Column(db.Integer, primary_key=True)
         title = db.Column(db.String(100), nullable=False)
-        memo = db.Column(db.String(100), nullable=False)
-        startdate = db.Column(db.String(100), nullable=False)
-        enddate = db.Column(db.String(100), nullable=False)
-        cycle = db.Column(db.Integer, nullable=False)
+        memo = db.Column(db.String(100), nullable=True)
+        startdate = db.Column(db.String(100), nullable=True)
+        enddate = db.Column(db.String(100), nullable=True)
+        cycle = db.Column(db.Integer, nullable=True)
 
         user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
         


### PR DESCRIPTION
1. medicines과 schedules_common 테이블에 nullable이 가능한 필드는 nullable=True로 수정하였습니다

0. pull 하신 뒤
`python manage.py db migrate`
`python manage.py db upgrade`
하시면 반영되실거에요!

1. 만약 에러가 나신다면(제가 했을 때는 에러가 나지 않았는데 hoxy나..) 사용하시는 DB에서 alembic_version 테이블 !만! drop하신다음 
(현주님께서 마이드레이션 폴더도 삭제해주었더니 잘 되었대요!!👏🏼)
`python manage.py db init`
`python manage.py db migrate`
`python manage.py db upgrade`
해보세용(https://stackoverflow.com/questions/57758213/unable-to-find-source-of-error-root-error-cant-locate-revision-identified-b)

*****
**마이그레이션 관련 알게된 것)** nodejs처럼 https://blog.outsider.ne.kr/1143 에서 나와있는 것 처럼 Alembic을 사용해서 `alembic revision -m "create user table[마이그레이션 명]"`을 하면
```
"""create user table[마이그레이션 명]

Revision ID: 2987e9c41e5e
Revises:
Create Date: 2015-05-10 22:10:18.235580

"""

# revision identifiers, used by Alembic.
revision = '2987e9c41e5e'
down_revision = None
branch_labels = None
depends_on = None

from alembic import op
import sqlalchemy as sa

def upgrade():
  pass

def downgrade():
  pass
``` 
이런 폴더가 생성이 되어서 직접 어떤걸 upgrade하고, downgrade할 건지를 pass자리에 적어주는 방법이 있다고 합니다.  
*****
그런데 저희는 그냥 먼저 model 파일 코드를 원하는대로 수정하고 
`python manage.py db migrate`
하면
위의 파일이 생성되고 upgrade에 수정된 내용, downgrade에 수정전 내용이 **자동으로 기입**되어져 만들어집니다. 
그리고
`python manage.py db upgrade`하시면 **자동으로 저희 DB에 반영되어요!** 