### PR TITLE
[Server]/fix/DB수정/Schedules_date수정

### DIFF
--- a/app/main/model/schedules_date.py
+++ b/app/main/model/schedules_date.py
@@ -6,7 +6,7 @@ class Schedules_date(db.Model):
     __tablename__ = "schedules_date"
 
     id = db.Column(db.Integer, primary_key=True)
-    date = db.Column(db.Date, nullable=False)
+    alarmdate = db.Column(db.Date, nullable=False)
     time = db.Column(db.Time, nullable=False)
     check = db.Column(db.Boolean, nullable=False)
   


### PR DESCRIPTION
year, month, date필드를 없애고, Date format의 [date 필드](https://www.w3schools.com/sql/sql_dates.asp) 추가하였습니다. 

저번과 동일하게 
`python manage.py db migrate`
`python manage.py db upgrade`
후 반드시 
desc schedules_date 또는 sequel pro에 가셔서 Date 타입으로 잘 바뀌셨는지 확인 부탁드립니다. 

