### PR TITLE
[Server]#10/Post Schedules Common Medicine API/구현 완료

### DIFF
--- a/app/main/controller/medicines.py
+++ b/app/main/controller/medicines.py
@@ -2,38 +2,40 @@ from flask import request, redirect, jsonify, make_response
 from flask_restx import Resource
 from ..util.dto import MedicineDto
 import requests
-from ..service.medicines import post_medicine
+from ..service.medicines import post_medicine, post_schedules_common_medicines
 
 api = MedicineDto.api
 # _medicines = MedicineDto.medicines
 
-"""
-클라에서 Request로 주는 약 정보
-{
-  "medicine": [
-    {"name": "타이레놀", 
-      "title": "머리 아플 때 먹어",
-      "image_dir": "https://s3.amazonaws.com/bucketname/foldername/image1.jpg",
-      "effect": "두통",
-      "capacity": "성인2알",
-      "validity": "개봉 후 2년",
-      "camera": false
-    }, 
-    {"name": "이가탄", 
-      "title": "이 아플 때 먹어",
-      "image_dir": "https://s3.amazonaws.com/bucketname/foldername/image2.jpg",
-      "effect": "치통",
-      "capacity": "성인1알",
-      "validity": "개봉 후 2년",
-      "camera": true
-    }
-  ]
-}
-라고 생각하고 구현
-"""
 @api.route('')
 class PostMedicine(Resource):
   def post(self):
     """Post Medicine API"""
     data = request.get_json().get('medicine') 
     return post_medicine(data)
+
+
+"""
+client에서
+{
+  "schedules_common_medicines":
+  {
+    "schedules_common_id": 1,
+    "medicine_id": [1, 2, 3]
+  }
+}
+이렇게 준다고 가정하고, 
+schedules_medicines 테이블에
+schedules_common_id | medicines_id
+          1         |     1
+          1         |     2
+          1         |     3
+이렇게 저장하는 것으로 구현
+"""
+
+@api.route('/schedules-medicines')
+class PostSchedulesCommonMedicines(Resource):
+  def post(self):
+    """Post Schedules Common Medicines API"""
+    data = request.get_json().get('schedules_common_medicines')
+    return post_schedules_common_medicines(data)

--- a/app/main/service/medicines.py
+++ b/app/main/service/medicines.py
@@ -3,6 +3,8 @@
 from flask import request, jsonify, redirect
 from flask_restx import Resource, fields, marshal
 from sqlalchemy import and_
+from sqlalchemy import create_engine
+from sqlalchemy.sql import text
 import json
 import jwt
 from datetime import time
@@ -10,10 +12,10 @@ from operator import itemgetter
 from app.main import db
 from app.main.model.medicines import Medicines
 from app.main.model.users import Users
-from ..config import jwt_key, jwt_alg
+from ..config import jwt_key, jwt_alg, DevelopmentConfig #배포때는 여기를 ProductionConfig로 해주어야 합니다. 
 
 def post_medicine(data):
-  """ Gost medicine information"""
+  """Post medicine information"""
   try:
     try:
       token = request.headers.get('Authorization')
@@ -42,6 +44,47 @@ def post_medicine(data):
           'medicine_id': medicine_ids
         }
         return response_object, 200
+    except Exception as e:
+      response_object = {
+        'status': 'fail',
+        'message': 'Provide a valid auth token.',
+      }
+      return response_object, 401
+      
+  except Exception as e:
+      response_object = {
+        'status': 'Internal Server Error',
+        'message': 'Some Internal Server Error occurred.',
+      }
+      return response_object, 500
+
+
+
+def post_schedules_common_medicines(data):
+  """Post schedules_common_id | medicines_id in schedules_medicines table 
+  Because that model exists, I wrote the query statement directly, not the ORM syntax.
+  reference: https://chartio.com/resources/tutorials/how-to-execute-raw-sql-in-sqlalchemy/
+  """
+  try:
+    schedules_common_id = data['schedules_common_id']
+    medicines_id = data['medicines_id']
+    try:
+      token = request.headers.get('Authorization')
+      decoded_token = jwt.decode(token, jwt_key, jwt_alg)
+      user_id = decoded_token['id']
+    
+      engine = create_engine(DevelopmentConfig.SQLALCHEMY_DATABASE_URI) #배포때는 여기를 ProductionConfig.SQLALCHEMY_DATABASE_URI 로 해주어야 합니다. 
+      query = text("""INSERT INTO schedules_medicines(schedules_common_id, medicines_id) VALUES (:each_schedules_common_id, :each_medicine_id)""")
+      each_schedules_common_id = schedules_common_id
+      with engine.connect() as con:
+        for each_medicine_id in medicines_id:
+          new_schedules_medicine = con.execute(query, {'each_schedules_common_id': each_schedules_common_id, 'each_medicine_id': each_medicine_id})
+
+      response_object = {
+        'status': 'OK',
+        'message': 'Successfully post schedules_common_id, medicines_id in schedules_medicines table.',
+      }
+      return response_object, 200
     except Exception as e:
       response_object = {
         'status': 'fail',

--- a/app/main/service/schedules_date.py
+++ b/app/main/service/schedules_date.py
@@ -80,38 +80,34 @@ def get_alarms_list(data):
   """ Get Alarms List on Clicked date for main page and calendar page"""
   try:
     alarmdate = datetime.datetime.strptime(data['date'], '%Y-%m-%d')
-
-    token = request.headers.get('Authorization')
-    decoded_token = jwt.decode(token, jwt_key, jwt_alg)
-    user_id = decoded_token['id']
-
-    if decoded_token:
-      """
-      schedules_date와 schedules_common을 innerjoin하여서 
-      schedules_date에서는 check, time
-      schedules_common에서는 title, cycle, memo
-      데이터를 가져와야한다. 
-      """
-      # reference: https://www.youtube.com/watch?v=_HIY1lZKEw0
-      data = db.session.query(Schedules_date.check, Schedules_date.time, Schedules_common.title, Schedules_common.cycle, Schedules_common.memo).filter(and_(Schedules_date.schedules_common_id == Schedules_common.id, Schedules_date.alarmdate==alarmdate, Schedules_date.user_id==user_id)).all()
-
-      results = []
-      for el in data:
-        result = {}
-        result['check'] = el.check
-        result['time'] = datetime.time.strftime(el.time, "%H:%M")
-        result['title'] = el.title
-        result['cycle'] = el.cycle
-        result['memo'] = el.memo
-        results.append(result)
-
-      results = sorting_time(results)
-      response_object = {
-        'status': 'OK',
-        'message': 'Successfully get monthly checked.',
-        'results': results
-      }
-      return response_object, 200
+    try:
+      token = request.headers.get('Authorization')
+      decoded_token = jwt.decode(token, jwt_key, jwt_alg)
+      user_id = decoded_token['id']
+      if decoded_token:
+        """
+        schedules_date와 schedules_common을 innerjoin하여서 
+        schedules_date에서는 check, time
+        schedules_common에서는 title, cycle, memo
+        데이터를 가져와야한다. 
+        """
+        data = db.session.query(Schedules_date.check, Schedules_date.time, Schedules_common.title, Schedules_common.cycle, Schedules_common.memo).filter(and_(Schedules_date.schedules_common_id == Schedules_common.id, Schedules_date.alarmdate==alarmdate, Schedules_date.user_id==user_id)).all() 
+        results = []
+        for el in data:
+          result = {}
+          result['check'] = el.check
+          result['time'] = datetime.time.strftime(el.time, "%H:%M")
+          result['title'] = el.title
+          result['cycle'] = el.cycle
+          result['memo'] = el.memo
+          results.append(result)
+        results = sorting_time(results)
+        response_object = {
+          'status': 'OK',
+          'message': 'Successfully get monthly checked.',
+          'results': results
+        }
+        return response_object, 200
     except Exception as e:
       response_object = {
         'status': 'fail',


### PR DESCRIPTION
done1 - get today list API try:누락으로 인한 syntax 에러 수정
done2 - PostSchedulesCommonMedicineAPI 구현 완료 및 주석으로 설명 남김

1. client에서
```
{
  "schedules_common_medicines":
  {
    "schedules_common_id": 1,
    "medicine_id": [1, 2, 3]
  }
}
```
이렇게 준다고 가정하고, 
schedules_medicines 테이블에
schedules_common_id | medicines_id
          1         |     1
          1         |     2
          1         |     3
이렇게 저장하는 것으로 구현하였습니다. 

2. API문서에 해당 API 추가 정보 업데이트 해놓았습니다. 

### 특이사항
schedules_medicines 테이블은 모델 class로 정의하지 않고 table선언만 해주었기 때문에 ORM 모델 쿼리문을 사용할 수 없고, Raw SQL문을 사용해야 합니다. 
https://chartio.com/resources/tutorials/how-to-execute-raw-sql-in-sqlalchemy/
을 참고하였습니다. 

### 유의사항
create_engine 부분은 개발 환경과 배포 환경의 SQLALCHEMY_DATABASE_URI가 다르기때문에

개발환경시에는 
```
from ..config import jwt_key, jwt_alg, DevelopmentConfig 
engine = create_engine(DevelopmentConfig.SQLALCHEMY_DATABASE_URI)
```
배포환경시에는 
```
from ..config import jwt_key, jwt_alg,  ProductionConfig 
engine = create_engine( ProductionConfig.SQLALCHEMY_DATABASE_URI)
```
가 되어야 합니다. 

postman과 sequel pro에서 잘 작동하는 것 확인하였습니다. 
![image](https://user-images.githubusercontent.com/55108539/101479764-10859680-3996-11eb-941c-bfb1df4ad6fc.png)




