### PR TITLE
[Server]fix/#10/주기 계산 오류 수정 및 응답 메세지 수정

### DIFF
--- a/app/main/service/medicines.py
+++ b/app/main/service/medicines.py
@@ -42,7 +42,7 @@ def post_medicine(data):
 
         response_object = {
           'status': 'OK',
-          'message': 'Successfully get monthly checked.',
+          'message': 'Successfully post medicine information.',
           'medicine_id': medicine_ids
         }
         return response_object, 200
@@ -62,7 +62,7 @@ def post_medicine(data):
 
 
 def upload_medicine(data):
-  """ Gost medicine information"""
+  """ Upload medicine information"""
   try:
     try:
       token = request.headers.get('Authorization')
@@ -92,18 +92,18 @@ def upload_medicine(data):
 
         #print(image_L_url)
         return image_L_url, 200
-     except Exception as e:
-       response_object = {
+    except Exception as e:
+      response_object = {
         'status': 'fail',
         'message': 'Provide a valid auth token.',
-       }
-       return response_object, 401
-   except Exception as e:  
+      }
+      return response_object, 401
+  except Exception as e:  
     response_object = {
       'status': 'Internal Server Error',
       'message': 'Some Internal Server Error occurred.',
-     }
-     return response_object, 500
+    }
+    return response_object, 500
 
 
 def post_schedules_common_medicines(data):

--- a/app/main/service/schedules_common.py
+++ b/app/main/service/schedules_common.py
@@ -39,7 +39,7 @@ def post_schedules_common(data):
         }
         response_object = {
           'status': 'OK',
-          'message': 'Successfully get monthly checked.',
+          'message': 'Successfully Post Common information of alarm.',
           'results': results
         }
         return response_object, 200
@@ -81,8 +81,6 @@ def post_schedules_date(data):
         #비교연산자로 기저조건을 걸어주고 주기 계산
         currdate = startdate
         while currdate <= enddate:
-          currdate = currdate + datetime.timedelta(days=cycle)
-          print("date: ", currdate)
           #이를 schedules_date 테이블에 넣어주기
           new_schedules_date = Schedules_date(
             alarmdate = currdate,
@@ -93,6 +91,7 @@ def post_schedules_date(data):
           )
           db.session.add(new_schedules_date)
           db.session.commit()
+          currdate = currdate + datetime.timedelta(days=cycle)
 
         #response는 medicine_id와 schedules_common_id
         results = {

--- a/app/main/service/schedules_date.py
+++ b/app/main/service/schedules_date.py
@@ -104,7 +104,7 @@ def get_alarms_list(data):
         results = sorting_time(results)
         response_object = {
           'status': 'OK',
-          'message': 'Successfully get monthly checked.',
+          'message': 'Successfully Get Alarms List on Clicked date for main page and calendar page.',
           'results': results
         }
         return response_object, 200


### PR DESCRIPTION
1. 
![image](https://user-images.githubusercontent.com/55108539/101615708-c8c44500-3a51-11eb-9d42-0c91f6959f75.png)

주기 계산 후 

![image](https://user-images.githubusercontent.com/55108539/101615676-be09b000-3a51-11eb-86db-987b4f8b0c18.png)

startdate, enddate, cycle을 변경하여서 여러번 테스트 완료 하여 `startdate <= alarmdate <=enddate`로 주기 계산이 되어서 schedules_date테이블에 insert되는 것 확인하였습니다. 

2. API의 200 status때의 message가 일치하지 않는 것들이 있어 수정하였습니다. 
3. 현주님께서 말씀하신 intent 에러 나는 부분 수정하였습니다. 
