### PR TITLE
[Server]Fix/post medicines

### DIFF
--- a/app/main/controller/medicines.py
+++ b/app/main/controller/medicines.py
@@ -2,7 +2,7 @@ from flask import request, redirect, jsonify, make_response
 from flask_restx import Resource
 from ..util.dto import MedicineDto
 import requests
-from ..service.medicines import post_medicine, post_schedules_common_medicines, upload_medicine
+from ..service.medicines import post_medicine, post_schedules_common_medicines, upload_medicine, post_users_medicines
 
 api = MedicineDto.api
 # _medicines = MedicineDto.medicines
@@ -50,6 +50,13 @@ schedules_common_id | medicines_id
           1         |     3
 이렇게 저장하는 것으로 구현
 """
+
+@api.route('/users-medicines')
+class PostUsersMedicines(Resource):
+  def post(self):
+    """Post Users Medicines API"""
+    data = request.get_json().get('medicines_id')
+    return post_users_medicines(data)
 
 @api.route('/schedules-medicines')
 class PostSchedulesCommonMedicines(Resource):


### PR DESCRIPTION
1. users_medicines N:N 테이블에도 user id 와 연동하는 작업 진행해 주어야 함. 
-> 저희가 또다른 N:N 테이블인 users_medicines 테이블을 잊었습니다..ㅠㅠ
-> /medicines/users_medicines API 추가 생성했습니다.

2. 약 등록 시에, 기존에 있는 약인지 체크하는 분기점 실행했습니다. 여기서 카메라 촬영 여부와 직접등록 여부에 따라서 분기가 달라져서
코드가 조금 길어졌습니다.
 a. 카메라 촬영 약인 경우 : 유저 id 상관 없이(즉 다른 사람 user id로 등록된 약이더라도) 그냥 중복이 되면 안됩니다! 
      왜냐면 약에 대한 정보들은 공공API에서 불러오므로 등록 유저 상관 없이 같은 약이면 모든 정보가 같을 것 이니까요.
   -> 따라서 전달되어온 약의 데이터에서 카메라 촬영어부를 탐색한뒤, 촬영된 약이면, 그냥 바로 medicines DB를 탐색합니다
 b. 직접 등록한 약의 경우 : 유저마다 구분을 지어줘야 합니다. 같은 약이름으로 지정하더라도 유저마다 직접 등록 시에 약에 대한 정보를 다르게 입력했을 경우가 높으니 구분해주어야 합니다.
   -> 따라서 users_medicines DB에서 user_id 기준으로 등록된 약의 id 받아온 다음에, 
      medicines DB에서 위의 id와 카메라촬영여부 F인 약만 가져왔습니다. 
   -> 그리고 받아온 데이터와 대조한뒤, 있으면, 바로 id 출력 /  없으면 등록 하는 것으로 진행했습니다.