### PR TITLE
[Server]/#13/feature/PatchCheckAPI/구현완료

### DIFF
--- a/app/main/controller/schedules_date.py
+++ b/app/main/controller/schedules_date.py
@@ -3,15 +3,30 @@ from flask_restx import Resource
 
 from ..util.dto import Schedules_dateDto
 import requests
-from ..service.schedules_date import get_monthly_checked, get_alarms_list
-from ..service.schedules_date import get_today_checked
+from ..service.schedules_date import get_monthly_checked, get_alarms_list, get_today_checked, patch_check
 
 api = Schedules_dateDto.api
 _schedules_date = Schedules_dateDto.schedules_date
 
+"""
+client에서 
+{
+  "schedules_common": 
+    {"schedules_common_id": 1, 
+      "clickdate": '2020-12-12',
+    }
+}
+의 형태로 보내준다고 생각하고 구현
+"""
+@api.route('/check')
+class PatchCheck(Resource):
+  def patch(self):
+    """Patch Check API"""
+    data = request.get_json().get('schedules_common') 
+    return patch_check(data)
+
 @api.route('/check/month') 
 class Check(Resource):
- 
   def get(self):
     """Get Montly Checked API"""
     data = request.args.to_dict()
@@ -28,9 +43,10 @@ class TodayAlarmList(Resource):
 
 @api.route('/check/today') 
 class Check(Resource):
- 
   def get(self):
     """Get Today Checked API"""
     data = request.args.to_dict()
     return get_today_checked(data)
+
+
 

--- a/app/main/model/schedules_date.py
+++ b/app/main/model/schedules_date.py
@@ -14,4 +14,4 @@ class Schedules_date(db.Model):
     schedules_common_id = db.Column(db.Integer, db.ForeignKey('schedules_common.id'), nullable=False)
 
     def __repr__(self):
-        return "<schedules_date '{}'>".format(self.year)
+        return "<schedules_date '{}'>".format(self.id)


### PR DESCRIPTION
done 1-  해당 날짜/시간의 알람 check을 true->false or false->true로 상태변경
done 2- schedules_Date 모델에서 데이터 select시 year 정보가 없어지면서 발생하는 에러해결

API문서에 
`http://localhost:4000/schedules_commons/schedules_dates/check`
로 uri가 정해져있었는데, 
이 API는 schedules_dates 테이블에만 관련된 API이므로 `http://localhost:4000/schedules_dates/check`로 변경하여 controller, service모두 schedules_date.py 에서 구현하였습니다.

request는 
```
{
  "schedules_common": 
    {"schedules_common_id": 1, 
      "clickdate": '2020-12-12',
    }
}
```

response는 
```
{
    "status": "OK",
    "message": "Successfully Convert check False to True or True to False.",
    "results": {
        "check": true[상태 변경된 check bool값]
    }
} 
```
로 구현하였습니다. 

Patch Check API의 구체적인 내용은 API문서 업데이트 해놓았습니다. 
https://github.com/codestates/medisharp-client/wiki/API#patch-check


