### PR TITLE
fix/post_users_medicines 머지 잘못된 부분 수정

### DIFF
--- a/app/main/service/medicines.py
+++ b/app/main/service/medicines.py
@@ -225,6 +225,7 @@ def post_users_medicines(data):
         response_object = {
           'status': 'OK',
           'message': 'Successfully post users_common_id, medicines_id in users_medicines table.',
+          'results' : req_medicines_id
         }
         return response_object, 200
     except Exception as e:


### PR DESCRIPTION
`'results' : req_medicines_id`가 401의 응답에 있어서 200의 응답으로 수정