### PR TITLE
[Server]/학습초기세팅/#8/데이터준비/약 정보 데이터 download 및 sampling

### DIFF
--- a/cnn/code/drug_image_data_download_prepare.ipynb
+++ b/cnn/code/drug_image_data_download_prepare.ipynb
@@ -1,0 +1,451 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import re\n",
+    "\n",
+    "import cv2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load Dataset\n",
+    "data = pd.read_csv('./공공데이터개방_낱알식별목록.csv')\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(23211, 30)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data['큰제품이미지']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>큰제품이미지</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                              큰제품이미지\n",
+       "0  https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...\n",
+       "1  https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...\n",
+       "2  https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...\n",
+       "3  https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...\n",
+       "4  https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow..."
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "image_url = pd.DataFrame(data['큰제품이미지'])\n",
+    "image_url.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "큰제품이미지    https://nedrug.mfds.go.kr/pbp/cmn/itemImageDow...\n",
+       "Name: 394, dtype: object"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "image_url.loc[394]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "큰제품이미지    0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.isnull(image_url).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>품목명</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>징카민정40mg(은행엽건조엑스)(수출명:징카프란정)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>아스코푸정(히벤즈산티페피딘)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>진셀몬정</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>저니스타서방정8밀리그램(히드로모르폰염산염)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>씨즈날정(세티리진염산염)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            품목명\n",
+       "0  징카민정40mg(은행엽건조엑스)(수출명:징카프란정)\n",
+       "1               아스코푸정(히벤즈산티페피딘)\n",
+       "2                          진셀몬정\n",
+       "3       저니스타서방정8밀리그램(히드로모르폰염산염)\n",
+       "4                 씨즈날정(세티리진염산염)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drug_name = pd.DataFrame(data['품목명'])\n",
+    "drug_name.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "https://nedrug.mfds.go.kr/pbp/cmn/itemImageDownload/147427960430900160\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(drug_name['품목명'][394]=='시알리스정20밀리그램(타다라필)')\n",
+    "print(image_url['큰제품이미지'][394])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def downImage(img_url, img_name):\n",
+    "    result_url = './drug_image_dataset/'\n",
+    "    urllib.request.urlretrieve(img_url, result_url+img_name+'.jpg')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'디아민정'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# drug_name['품목명'][68].split('/')[0]\n",
+    "re.split('[/,-,(,). :]','디아민정(글리클라짓)(수출명:Bee-DiaminTablet|Meracron80mgTab)')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for i, row in image_url.iterrows():\n",
+    "# #     print('row',i,'url', row['큰제품이미지'])\n",
+    "#     if 'https://' in row['큰제품이미지']:\n",
+    "#         downImage(row['큰제품이미지'], re.split('[/,-,(,). :]',drug_name['품목명'][i])[0])\n",
+    "    \n",
+    "#     #if do not re.split('[/,-,(,). :]', there could be error like this.\n",
+    "#     #[Errno 2] No such file or directory: './drug_image_dataset/발탄플러스정160/12.5밀리그램.jpg'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "의약품제형\n",
+       "원형       9164\n",
+       "장방형      7421\n",
+       "타원형      5314\n",
+       "기타        482\n",
+       "삼각형       237\n",
+       "팔각형       223\n",
+       "사각형       214\n",
+       "오각형        76\n",
+       "육각형        51\n",
+       "마름모형       27\n",
+       "반원형         2\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drug_shape = pd.DataFrame(data['의약품제형'])\n",
+    "drug_shape.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#spliting dataset w.r.t 의약품제형\n",
+    "Circles = data[(data['의약품제형']=='원형')]\n",
+    "Ovals = data[(data['의약품제형']=='타원형')]\n",
+    "Rectangles = data[(data['의약품제형']=='장방형')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(9164, 30)\n",
+      "(5314, 30)\n",
+      "(7421, 30)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(Circles.shape)\n",
+    "print(Ovals.shape)\n",
+    "print(Rectangles.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#devide file w.r.t 의약품제형\n",
+    "import shutil\n",
+    "\n",
+    "src = './drug_image_dataset/'\n",
+    "Circles_dst = './drug/Circles/'\n",
+    "Ovals_dst = './drug/Ovals'\n",
+    "Rectangles_dst = './drug/Rectangles'\n",
+    "\n",
+    "\n",
+    "def copy_file(src, dst, drug_shape_data, shape):\n",
+    "    for i, row in drug_shape_data.iterrows():\n",
+    "        if 'https://' in row['큰제품이미지'] and row['의약품제형']==shape:\n",
+    "            shutil.copy(src + re.split('[/,-,(,). :]',drug_name['품목명'][i])[0]+'.jpg', dst)\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# copy_file(src, Circles_dst, Circles,'원형') #8942 - 1(null image) = 8941\n",
+    "# copy_file(src, Ovals_dst, Ovals,'타원형') #5032\n",
+    "# copy_file(src, Rectangles_dst, Rectangles, '장방형')#7321"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
`의약품안전나라`에서 제공하는 csv파일로부터 약 정보와 학습시킬 이미지 다운로드
약 모양(의약품제형)을 기준으로 sampling 및 약 이름 등 특수문자 정리
데이터 수 파악
```
의약품제형
원형       9164
장방형      7421
타원형      5314
기타        482
삼각형       237
팔각형       223
사각형       214
오각형        76
육각형        51
마름모형       27
반원형         2
```