### PR TITLE
[Server]/#40/First Loading API/구현완료

### DIFF
--- a/app/main/controller/users.py
+++ b/app/main/controller/users.py
@@ -113,7 +113,7 @@ class KakaoSignInCallback(Resource):
 
         return social_signin(data=data) # 이젠 위에서 받은 데이터를 DB에 넣어줘야 합니다. 이 과정이 service에서 진행됩니다.
 
-@api.route('isloading')
+@api.route('/isloading')
 class FirstLoading(Resource):
     def get(self):
         """Check Server is Ready"""

--- a/app/main/service/users.py
+++ b/app/main/service/users.py
@@ -484,26 +484,15 @@ def edit_user_info(data):
 def get_first_loading():
   """Check Server is Ready"""
   try:
-    try:
-      response_object = {
-        'status': 'OK',
-        'message': 'Server is Successfully Ready.',
-      }
-      return response_object, 200
-    except Exception as e:
-      db.session.rollback()
-      raise
-      print(e)
-      response_object = {
-        'status': 'fail',
-        'message': 'Provide a valid auth token.',
-      }
-      return response_object, 400
-    finally:
-      db.session.close()
+    user_info = Users.query.all()
+    response_object = {
+      'status': 'OK',
+      'message': 'Server is Successfully Ready.',
+    }
+    return response_object, 200
   except Exception as e:
-      response_object = {
-        'status': 'Internal Server Error',
-        'message': 'Some Internal Server Error occurred.',
-      }
-      return response_object, 500
+    response_object = {
+      'status': 'Internal Server Error',
+      'message': 'Some Internal Server Error occurred.',
+    }
+    return response_object, 500


### PR DESCRIPTION
처음 로딩화면에서 서버가 준비되면 본격적인 서비스 HomeScreen을 보여주기위해
서버가 준비되었는지 확인을 위한 API입니다. 그래서 token이나 params나 아무런 데이터를 검사해주지 않습니다. 
처음에는 DB에는 쿼리문을 날리지 않고 그냥 서버에 한 번 갔다 오는것으로 구현했었는데, 그러다보니 DB가 준비되는 시간이 간과되는건지 여전히 서버가 준비되기 전에 HomeScreen으로 넘어가면서  503에러를 발생시켰습니다. 

그래서 굳이(ㅎㅎ)
`user_info = Users.query.all()`을 넣어주었습니다. 